### PR TITLE
Fix XSS in user signup

### DIFF
--- a/js/todos.js
+++ b/js/todos.js
@@ -341,7 +341,7 @@ $(function() {
         },
 
         error: function(user, error) {
-          self.$(".signup-form .error").html(error.message).show();
+          self.$(".signup-form .error").html(_.escape(error.message)).show();
           self.$(".signup-form button").removeAttr("disabled");
         }
       });


### PR DESCRIPTION
Hi, I'm a new Facebook employee in Bootcamp. I saw this bug and I'm submitting a pull request for a fix. I'll also respond on the task internally. Tested with XSS-inducing input and verified response from server is properly escaped now during signup failure. Looked for potential XSS vectors and found none.
